### PR TITLE
New translations for each user rent

### DIFF
--- a/app/controllers/api/v1/rents_controller.rb
+++ b/app/controllers/api/v1/rents_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class RentsController < ApplicationController
-      before_action :authenticate_user!
+      before_action :authenticate_user!, :set_locale
       def index
         user = User.find(params[:user_id])
         render_paginated user.rents, each_serializer: RentSerializer
@@ -20,6 +20,10 @@ module Api
 
       def rent_params
         params.require(:rent).permit(:user_id, :book_id, :start, :end)
+      end
+
+      def set_locale
+        I18n.locale = current_user.try(:locale) || I18n.default_locale
       end
     end
   end

--- a/app/mailers/rent_mailer.rb
+++ b/app/mailers/rent_mailer.rb
@@ -3,6 +3,6 @@ class RentMailer < ApplicationMailer
     @user = rent.user
     @rent = rent
     @book = rent.book
-    mail(to: @user.email, subject: 'New Rent was Created')
+    mail(to: @user.email, subject: I18n.t('email.new_rent.mail_header'))
   end
 end

--- a/app/views/rent_mailer/new_rent_created.html.erb
+++ b/app/views/rent_mailer/new_rent_created.html.erb
@@ -9,18 +9,18 @@
 
   <body>
     <div>
-    <h1> There are a new Rent in your account!</h1>
-      <p> Rent created at: <%= Time.now %></p>
-      <h3>Book Details:</h3> 
+    <h1> <%= t('email.new_rent.mail_header') %></h1>
+      <p> <%= t('email.new_rent.rent_created_at')%>: <%= Time.now %></p>
+      <h3><%= t('email.new_rent.book_details')%>:</h3> 
       <ul>
-        <li><b>Title:</b> <%= @book.title %></li>
-        <li><b>Author:</b> <%= @book.author %></li>
-        <li><b>Genre:</b> <%= @book.genre %></li>
-        <li><b>Editor:</b> <%= @book.editor %></li>
-        <li><b>Year:</b> <%= @book.year %></li>
+        <li><b><%= t('email.new_rent.title')%>:</b> <%= @book.title %></li>
+        <li><b><%= t('email.new_rent.author')%>:</b> <%= @book.author %></li>
+        <li><b><%= t('email.new_rent.genre')%>:</b> <%= @book.genre %></li>
+        <li><b><%= t('email.new_rent.editor')%>:</b> <%= @book.editor %></li>
+        <li><b><%= t('email.new_rent.year')%>:</b> <%= @book.year %></li>
       </ul>
       <hr>
-      <p>Period of the rent: <%= @rent.start %> - <%= @rent.end %></p>
+      <p><%= t('email.new_rent.rent_period')%>: <%= @rent.start %> - <%= @rent.end %></p>
     </div>
   </body>
 </html>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -29,17 +29,17 @@
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
 
-en:
-  hello: "Hello"
+es:
+  hello: "Hola"
   email:
     new_rent:
-      mail_header: "There are a new Rent in your account!"
-      rent_created_at: "Rent created at"
-      book_details: "Book Details"
-      title: "Title"
-      author: "Author"
-      genre: "Genre"
+      mail_header: "Hay un nuevo alquiler en su cuenta!"
+      rent_created_at: "Alquiler creado el"
+      book_details: "Detalle de libro"
+      title: "Titulo"
+      author: "Autor"
+      genre: "Género"
       editor: "Editor"
-      year: "Year"
-      rent_period: "Period of the rent"
-      new_rent_subject: "New Rent was Created"
+      year: "Año"
+      rent_period: "Período del alquiler"
+      new_rent_subject: "Nuevo Alquiler registrado"

--- a/db/migrate/20181210141608_add_locale_to_users.rb
+++ b/db/migrate/20181210141608_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_03_161552) do
+ActiveRecord::Schema.define(version: 2018_12_10_141608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "books", force: :cascade do |t|
-    t.string "genre"
-    t.string "author"
-    t.string "image"
-    t.string "title"
-    t.string "editor"
-    t.integer "year"
+    t.string "genre", null: false
+    t.string "author", null: false
+    t.string "image", null: false
+    t.string "title", null: false
+    t.string "editor", null: false
+    t.integer "year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -50,20 +50,8 @@ ActiveRecord::Schema.define(version: 2018_12_03_161552) do
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
     t.boolean "allow_password_change", default: false
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.string "name"
-    t.string "nickname"
-    t.string "image"
     t.json "tokens"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.string "locale"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true


### PR DESCRIPTION
### Summary
I18n was implemented for translate user mailing. New column "locale" in "Users" for set his language preference.
### ScreenShoots.
![image](https://user-images.githubusercontent.com/8608635/49741374-0a5c6280-fc75-11e8-9e18-f6419e7a6617.png)
![image](https://user-images.githubusercontent.com/8608635/49741407-1a744200-fc75-11e8-8d06-bbaf367dce95.png)
### Trello
https://trello.com/c/DBWMrSr6/25-internacionalizar-el-email